### PR TITLE
Fix add to cart button on product theme

### DIFF
--- a/src/themes/default/ProductDetail.jsx
+++ b/src/themes/default/ProductDetail.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
+import { useCart } from '../../contexts/CartContext.jsx';
 
 const products = [
   {
@@ -50,6 +51,7 @@ const products = [
 
 export default function ProductDetail() {
   const { id } = useParams();
+  const { addItem } = useCart();
   const product = products.find((p) => p.id === id);
 
   if (!product) {
@@ -98,6 +100,7 @@ export default function ProductDetail() {
                 ${product.stock === 0 ? 'bg-gray-400 cursor-not-allowed text-white' : 'bg-gold text-black hover:bg-[#c09d31]'}
               `}
               disabled={product.stock === 0}
+              onClick={() => addItem({ id: product.id, name: product.name, price: product.price, image: product.image })}
             >
               {product.stock === 0 ? 'No disponible' : 'Agregar al carrito'}
             </button>

--- a/src/themes/default/Products.jsx
+++ b/src/themes/default/Products.jsx
@@ -1,9 +1,11 @@
 import React, { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useCart } from '../../contexts/CartContext.jsx';
 
 
 
 export default function Products(items) {
+  const { addItem } = useCart();
   const PRODUCTS_PER_PAGE = 9;
 
   const allProducts = useMemo(() => {
@@ -161,7 +163,6 @@ export default function Products(items) {
   }, []);
 
   const [stock, setStock] = useState(items ? items.stock : 0);
-  const [productsState, setProductsState] = useState(items);
 
   if (!items) {
     return <h2 className="text-center text-red-600 mt-16">Producto no encontrado</h2>;
@@ -181,20 +182,9 @@ export default function Products(items) {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
-const handleAddToCart = (productId) => {
-  setProductsState(prevProducts =>
-    prevProducts.map(p => {
-      if (p.id === productId && p.stock > 0) {
-        return { ...p, stock: p.stock - 1 }; // reducimos stock
-      }
-      return p;
-    })
-  );
-
-  const product = productsState.find(p => p.id === productId);
-  if (product && product.stock > 0) {
-    console.log(`Agregaste 1 unidad de ${product.name} al carrito`);
-  }
+const handleAddToCart = (product) => {
+  if (product.stock === 0) return;
+  addItem({ id: product.id, name: product.name, price: Number(product.price), image: product.image });
 };
 
 
@@ -238,11 +228,10 @@ const handleAddToCart = (productId) => {
                         <button
                           className="btn btn-sm btn-primary"
                           disabled={product.stock === 0}
+                          onClick={() => handleAddToCart(product)}
                         >
                           {product.stock === 0 ? 'No disponible' : 'Añadir al carrito'}
                         </button>
-
-                        <button onClick={() => handleAddToCart(product.id)}>Agregar al carrito</button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Wire primary 'Add to Cart' buttons in product listings and detail pages to the cart context and remove a duplicate non-functional button.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f9d5bd7-0e16-4f99-ad83-dc5ecf7e0a69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f9d5bd7-0e16-4f99-ad83-dc5ecf7e0a69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

