### PR TITLE
Generate product category images

### DIFF
--- a/public/images/categories/cabello.svg
+++ b/public/images/categories/cabello.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" fill="none">
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7BDFF2"/>
+      <stop offset="100%" stop-color="#B2F7EF"/>
+    </linearGradient>
+    <linearGradient id="g2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FDE68A"/>
+      <stop offset="100%" stop-color="#FCD34D"/>
+    </linearGradient>
+    <linearGradient id="g3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FCA5A5"/>
+      <stop offset="100%" stop-color="#F87171"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+
+  <!-- Background accent -->
+  <rect x="24" y="24" width="464" height="464" rx="28" fill="#ffffff"/>
+
+  <!-- Shampoo bottle -->
+  <g filter="url(#shadow)">
+    <rect x="74" y="122" width="120" height="260" rx="28" fill="url(#g1)" stroke="#1F2937" stroke-width="6"/>
+    <rect x="104" y="94" width="60" height="36" rx="10" fill="#93C5FD" stroke="#1F2937" stroke-width="6"/>
+    <rect x="112" y="84" width="44" height="18" rx="6" fill="#60A5FA" stroke="#1F2937" stroke-width="4"/>
+    <circle cx="134" cy="252" r="26" fill="#E0F2FE" stroke="#1F2937" stroke-width="5"/>
+  </g>
+
+  <!-- Conditioner bottle -->
+  <g filter="url(#shadow)">
+    <rect x="206" y="146" width="120" height="236" rx="36" fill="url(#g2)" stroke="#1F2937" stroke-width="6"/>
+    <rect x="236" y="118" width="60" height="36" rx="10" fill="#F59E0B" stroke="#1F2937" stroke-width="6"/>
+    <rect x="244" y="108" width="44" height="18" rx="6" fill="#D97706" stroke="#1F2937" stroke-width="4"/>
+    <path d="M266 240c14 0 26 12 26 26s-12 26-26 26-26-12-26-26 12-26 26-26z" fill="#FEF3C7" stroke="#1F2937" stroke-width="5"/>
+  </g>
+
+  <!-- Hair oil: bottle + drop -->
+  <g filter="url(#shadow)">
+    <rect x="338" y="170" width="100" height="212" rx="22" fill="url(#g3)" stroke="#1F2937" stroke-width="6"/>
+    <rect x="362" y="142" width="52" height="32" rx="8" fill="#FB7185" stroke="#1F2937" stroke-width="6"/>
+    <path d="M388 274c18 26 28 40 28 56 0 22-18 40-40 40s-40-18-40-40c0-16 10-30 28-56 4-6 12-6 16 0z" fill="#FDE2E2" stroke="#1F2937" stroke-width="6"/>
+  </g>
+
+  <!-- Label text -->
+  <text x="256" y="460" text-anchor="middle" font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto" font-size="28" fill="#111827">Cabello</text>
+</svg>
+

--- a/public/images/categories/ofertas.svg
+++ b/public/images/categories/ofertas.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" fill="none">
+  <defs>
+    <linearGradient id="hot" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F97316"/>
+      <stop offset="100%" stop-color="#EF4444"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+
+  <rect x="24" y="24" width="464" height="464" rx="28" fill="#ffffff"/>
+
+  <!-- Price tag with percent symbol -->
+  <g filter="url(#shadow)">
+    <path d="M120 188l84-84h124l64 64v172c0 18-14 32-32 32H152c-18 0-32-14-32-32V188z" fill="url(#hot)" stroke="#111827" stroke-width="8"/>
+    <circle cx="192" cy="212" r="14" fill="#fff"/>
+    <path d="M214 334l84-108" stroke="#fff" stroke-width="18" stroke-linecap="round"/>
+    <circle cx="320" cy="316" r="14" fill="#fff"/>
+  </g>
+
+  <text x="256" y="460" text-anchor="middle" font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto" font-size="28" fill="#111827">Ofertas</text>
+</svg>
+

--- a/public/images/categories/tazones.svg
+++ b/public/images/categories/tazones.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" fill="none">
+  <defs>
+    <linearGradient id="copper" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#B87333"/>
+      <stop offset="100%" stop-color="#D18F4E"/>
+    </linearGradient>
+    <linearGradient id="steel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9CA3AF"/>
+      <stop offset="100%" stop-color="#6B7280"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+
+  <rect x="24" y="24" width="464" height="464" rx="28" fill="#ffffff"/>
+
+  <!-- Copper beer mug (tazón chopero de cobre) -->
+  <g filter="url(#shadow)">
+    <rect x="92" y="160" width="148" height="180" rx="16" fill="url(#copper)" stroke="#1F2937" stroke-width="8"/>
+    <rect x="92" y="140" width="148" height="28" rx="10" fill="#EDC39E" stroke="#1F2937" stroke-width="6"/>
+    <rect x="104" y="180" width="124" height="24" rx="6" fill="#EAD3BA" opacity="0.55"/>
+    <path d="M250 182c26-18 56-10 70 4v80c-14 14-44 22-70 4" fill="none" stroke="#1F2937" stroke-width="10"/>
+    <path d="M250 186c26-18 56-10 70 4v72c-14 14-44 22-70 4" fill="#FDE68A" opacity="0.35"/>
+  </g>
+
+  <!-- Stainless steel beer mug (tazón chopero de acero inoxidable) -->
+  <g filter="url(#shadow)">
+    <rect x="286" y="160" width="148" height="180" rx="16" fill="url(#steel)" stroke="#111827" stroke-width="8"/>
+    <rect x="286" y="140" width="148" height="28" rx="10" fill="#D1D5DB" stroke="#111827" stroke-width="6"/>
+    <rect x="298" y="180" width="124" height="24" rx="6" fill="#E5E7EB" opacity="0.7"/>
+    <path d="M286 182c-26-18-56-10-70 4v80c14 14 44 22 70 4" fill="none" stroke="#111827" stroke-width="10"/>
+    <path d="M286 186c-26-18-56-10-70 4v72c14 14 44 22 70 4" fill="#D1FAE5" opacity="0.25"/>
+  </g>
+
+  <text x="256" y="460" text-anchor="middle" font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto" font-size="28" fill="#111827">Tazones schoperos</text>
+</svg>
+


### PR DESCRIPTION
Add SVG category images for 'Cabello', 'Tazones', and 'Ofertas' to fulfill the user's request.

---
<a href="https://cursor.com/background-agent?bcId=bc-be4e1789-c3fd-45b3-be6e-a50354b4f49e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be4e1789-c3fd-45b3-be6e-a50354b4f49e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

