### PR TITLE
Fix hair category images and check others

### DIFF
--- a/public/images/categories/accesorios.svg
+++ b/public/images/categories/accesorios.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" fill="none">
+  <defs>
+    <linearGradient id="accent1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#A78BFA"/>
+      <stop offset="100%" stop-color="#60A5FA"/>
+    </linearGradient>
+    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#34D399"/>
+      <stop offset="100%" stop-color="#10B981"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect x="24" y="24" width="464" height="464" rx="28" fill="#ffffff"/>
+
+  <!-- Hair dryer -->
+  <g filter="url(#shadow)">
+    <path d="M132 292h92c28 0 52-20 58-47l3-14c2-8-4-15-12-15H172c-22 0-40 18-40 40v36z" fill="url(#accent1)" stroke="#1F2937" stroke-width="8"/>
+    <rect x="116" y="292" width="44" height="72" rx="10" fill="#93C5FD" stroke="#1F2937" stroke-width="8"/>
+    <circle cx="300" cy="244" r="10" fill="#FFFFFF"/>
+    <path d="M320 244h34" stroke="#1F2937" stroke-width="8" stroke-linecap="round"/>
+    <path d="M320 260h34" stroke="#1F2937" stroke-width="8" stroke-linecap="round"/>
+  </g>
+
+  <!-- Comb -->
+  <g filter="url(#shadow)">
+    <rect x="308" y="316" width="96" height="24" rx="10" fill="url(#accent2)" stroke="#111827" stroke-width="6"/>
+    <path d="M316 316v24M328 316v24M340 316v24M352 316v24M364 316v24M376 316v24M388 316v24M400 316v24" stroke="#111827" stroke-width="6" stroke-linecap="round"/>
+  </g>
+
+  <text x="256" y="460" text-anchor="middle" font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto" font-size="28" fill="#111827">Accesorios</text>
+</svg>
+

--- a/src/themes/default/Home.jsx
+++ b/src/themes/default/Home.jsx
@@ -81,9 +81,9 @@ export default function Home() {
         </div>
         <div className="row g-3 g-md-4">
           {[
-            { title: 'Cabello', slug: 'cabello', image: 'https://picsum.photos/seed/cabello/800/600' },
-            { title: 'Accesorios', slug: 'accesorios', image: 'https://picsum.photos/seed/accesorios/800/600' },
-            { title: 'Ofertas', slug: 'ofertas', image: 'https://picsum.photos/seed/ofertas/800/600' }
+            { title: 'Cabello', slug: 'cabello', image: '/images/categories/cabello.svg' },
+            { title: 'Accesorios', slug: 'accesorios', image: '/images/categories/accesorios.svg' },
+            { title: 'Ofertas', slug: 'ofertas', image: '/images/categories/ofertas.svg' }
           ].map((cat) => (
             <div key={cat.slug} className="col-12 col-md-4">
               <Link to={`/products/${cat.slug}`} className="text-decoration-none">


### PR DESCRIPTION
Replace placeholder category images with specific local SVG assets to correct display and ensure consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-21150df2-e08b-4a81-a23a-386388c7f24a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21150df2-e08b-4a81-a23a-386388c7f24a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

