### PR TITLE
Eliminar nombre de categoría de imágenes en Home

### DIFF
--- a/src/themes/default/Home.jsx
+++ b/src/themes/default/Home.jsx
@@ -88,7 +88,7 @@ export default function Home() {
             <div key={cat.slug} className="col-12 col-md-4">
               <Link to={`/products/${cat.slug}`} className="text-decoration-none">
                 <div className="card category-card h-100 overflow-hidden">
-                  <img src={cat.image} className="card-img-top" alt={cat.title} loading="lazy" style={{ objectFit: 'cover', aspectRatio: '4 / 3' }} />
+                  <img src={cat.image} className="card-img-top" alt={cat.title} loading="lazy" style={{ objectFit: 'contain', aspectRatio: '4 / 3', backgroundColor: '#fff' }} />
                   <div className="card-img-overlay d-flex align-items-end p-0">
                     <div className="w-100 p-3 category-overlay">
                       <h3 className="h5 mb-0 text-white">{cat.title}</h3>


### PR DESCRIPTION
Adjust category image styling to prevent embedded text from being cut off on the Home page.

---
<a href="https://cursor.com/background-agent?bcId=bc-f123c70a-8394-45a0-8389-41ec6da23ae6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f123c70a-8394-45a0-8389-41ec6da23ae6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

