### PR TITLE
Fix unauthorized api user info access

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,6 +11,7 @@ import WhatsAppBot from './components/WhatsAppBot.jsx';
 import { UserProvider } from './contexts/UserContext.jsx';
 import { CartProvider } from './contexts/CartContext.jsx';
 import { SEOProvider } from './contexts/SEOContext.jsx';
+import { installDevConsoleFilter } from './utils/devConsoleFilter.js';
 
 async function enableMocks() {
   if (import.meta.env.DEV || ['localhost', '127.0.0.1'].includes(window.location.hostname)) {
@@ -19,6 +20,7 @@ async function enableMocks() {
   }
 }
 
+installDevConsoleFilter();
 enableMocks().finally(() => {
   ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>

--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -1,4 +1,4 @@
-import { setupWorker } from 'msw';
+import { setupWorker } from 'msw/browser';
 import { handlers } from './handlers';
 
 export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -2,6 +2,14 @@ import { http, HttpResponse } from 'msw';
 import { products } from '../data/products.js';
 
 export const handlers = [
+  // External extension: mock user info to avoid noisy 401/HTML responses in dev
+  http.get('https://www.ag-translate.com/api/userInfo', () => {
+    return HttpResponse.json({ authenticated: false, user: null }, { status: 200 });
+  }),
+  http.get('https://ag-translate.com/api/userInfo', () => {
+    return HttpResponse.json({ authenticated: false, user: null }, { status: 200 });
+  }),
+
   // List all products
   http.get('/api/products', () => {
     return HttpResponse.json(products, { status: 200 });

--- a/src/utils/devConsoleFilter.js
+++ b/src/utils/devConsoleFilter.js
@@ -1,0 +1,39 @@
+// Filters console errors/warnings from known noisy browser extensions during development.
+// This does not affect production builds.
+
+export function installDevConsoleFilter() {
+  if (typeof window === 'undefined') return;
+  if (!import.meta || import.meta.env.PROD) return;
+
+  const noisyPatterns = [
+    /ag-translate\.com\/api\/userInfo/i,
+    /chrome-extension:\/\//i,
+    /Unexpected token '<', "<!doctype "/i,
+  ];
+
+  const originalError = console.error;
+  const originalWarn = console.warn;
+
+  function shouldSuppress(args) {
+    try {
+      const text = args.map((a) => {
+        if (a && typeof a.stack === 'string') return a.stack;
+        return typeof a === 'string' ? a : JSON.stringify(a);
+      }).join(' ');
+      return noisyPatterns.some((re) => re.test(text));
+    } catch {
+      return false;
+    }
+  }
+
+  console.error = (...args) => {
+    if (shouldSuppress(args)) return;
+    originalError.apply(console, args);
+  };
+
+  console.warn = (...args) => {
+    if (shouldSuppress(args)) return;
+    originalWarn.apply(console, args);
+  };
+}
+


### PR DESCRIPTION
Add MSW mocks for `/api/userInfo` and a dev-only console filter to silence noisy browser extension errors during development.

The `ag-translate` browser extension was making requests to `/api/userInfo` which resulted in 401 responses (HTML, not JSON), causing "Unexpected token '<'" errors in the console. These changes provide a mock JSON response for these external calls and filter the console output to improve the developer experience without affecting the application's functionality or production build.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a40c532-480c-4428-bad8-01fb43f06f76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a40c532-480c-4428-bad8-01fb43f06f76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

