### PR TITLE
feat(images): usar URLs remotas atractivas y SVGs sin texto

### DIFF
--- a/public/assets/products/CAB-ACE-001.svg
+++ b/public/assets/products/CAB-ACE-001.svg
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#fff7ed"/>
       <stop offset="100%" stop-color="#fde68a"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><path d="M120 460 C 200 380, 260 520, 340 440 S 500 500, 540 420" stroke="#7c3e0a" stroke-width="10" fill="none" stroke-linecap="round" />
               <path d="M80 380 C 160 300, 220 440, 300 360 S 460 420, 520 340" stroke="#a16207" stroke-width="8" fill="none" stroke-linecap="round" /></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#1f2937">Plus Vinge · aceite</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Aceite de Argan con</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Colageno - 1000 ml</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#7c3e0a"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">CAB-ACE-001</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/CAB-ACE-002.svg
+++ b/public/assets/products/CAB-ACE-002.svg
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#fff7ed"/>
       <stop offset="100%" stop-color="#fde68a"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><path d="M120 460 C 200 380, 260 520, 340 440 S 500 500, 540 420" stroke="#7c3e0a" stroke-width="10" fill="none" stroke-linecap="round" />
               <path d="M80 380 C 160 300, 220 440, 300 360 S 460 420, 520 340" stroke="#a16207" stroke-width="8" fill="none" stroke-linecap="round" /></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#1f2937">Moroccan · aceite</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Aceite Luxury Moroccan</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Argan Oil - 60 ml</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#7c3e0a"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">CAB-ACE-002</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/CAB-ACE-003.svg
+++ b/public/assets/products/CAB-ACE-003.svg
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#fff7ed"/>
       <stop offset="100%" stop-color="#fde68a"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><path d="M120 460 C 200 380, 260 520, 340 440 S 500 500, 540 420" stroke="#7c3e0a" stroke-width="10" fill="none" stroke-linecap="round" />
               <path d="M80 380 C 160 300, 220 440, 300 360 S 460 420, 520 340" stroke="#a16207" stroke-width="8" fill="none" stroke-linecap="round" /></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#1f2937">Luxe Line · aceite</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Aceite extreme caviar</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Haircare Luxe Line - 100</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#7c3e0a"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">CAB-ACE-003</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/CAB-ACE-004.svg
+++ b/public/assets/products/CAB-ACE-004.svg
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#fff7ed"/>
       <stop offset="100%" stop-color="#fde68a"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><path d="M120 460 C 200 380, 260 520, 340 440 S 500 500, 540 420" stroke="#7c3e0a" stroke-width="10" fill="none" stroke-linecap="round" />
               <path d="M80 380 C 160 300, 220 440, 300 360 S 460 420, 520 340" stroke="#a16207" stroke-width="8" fill="none" stroke-linecap="round" /></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#1f2937">Marca · aceite</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Aceite de Nuez Marroqui</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Profesional - 55 ml</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#7c3e0a"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">CAB-ACE-004</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/CAB-ACO-001.svg
+++ b/public/assets/products/CAB-ACO-001.svg
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#fff7ed"/>
       <stop offset="100%" stop-color="#fde68a"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><path d="M120 460 C 200 380, 260 520, 340 440 S 500 500, 540 420" stroke="#7c3e0a" stroke-width="10" fill="none" stroke-linecap="round" />
               <path d="M80 380 C 160 300, 220 440, 300 360 S 460 420, 520 340" stroke="#a16207" stroke-width="8" fill="none" stroke-linecap="round" /></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#1f2937">Plus Vinge · conditioner</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Acondicionador Collagen</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">- 1000 ml</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#7c3e0a"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">CAB-ACO-001</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/CAB-ACO-002.svg
+++ b/public/assets/products/CAB-ACO-002.svg
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#fff7ed"/>
       <stop offset="100%" stop-color="#fde68a"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><path d="M120 460 C 200 380, 260 520, 340 440 S 500 500, 540 420" stroke="#7c3e0a" stroke-width="10" fill="none" stroke-linecap="round" />
               <path d="M80 380 C 160 300, 220 440, 300 360 S 460 420, 520 340" stroke="#a16207" stroke-width="8" fill="none" stroke-linecap="round" /></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#1f2937">Rocco · conditioner</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Acondicionador Curl</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Perfect 3 en 1 - 500 ml</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#7c3e0a"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">CAB-ACO-002</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/CAB-ACO-003.svg
+++ b/public/assets/products/CAB-ACO-003.svg
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#fff7ed"/>
       <stop offset="100%" stop-color="#fde68a"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><path d="M120 460 C 200 380, 260 520, 340 440 S 500 500, 540 420" stroke="#7c3e0a" stroke-width="10" fill="none" stroke-linecap="round" />
               <path d="M80 380 C 160 300, 220 440, 300 360 S 460 420, 520 340" stroke="#a16207" stroke-width="8" fill="none" stroke-linecap="round" /></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#1f2937">Rocco · conditioner</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Acondicionador Jalea</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Real Anticaida 400 ml</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#7c3e0a"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">CAB-ACO-003</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/CAB-SHA-001.svg
+++ b/public/assets/products/CAB-SHA-001.svg
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#fff7ed"/>
       <stop offset="100%" stop-color="#fde68a"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><path d="M120 460 C 200 380, 260 520, 340 440 S 500 500, 540 420" stroke="#7c3e0a" stroke-width="10" fill="none" stroke-linecap="round" />
               <path d="M80 380 C 160 300, 220 440, 300 360 S 460 420, 520 340" stroke="#a16207" stroke-width="8" fill="none" stroke-linecap="round" /></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#1f2937">Plus Vinge · shampoo</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Shampoo Collagen - 1000</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">ml</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#7c3e0a"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">CAB-SHA-001</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/CAB-SHA-002.svg
+++ b/public/assets/products/CAB-SHA-002.svg
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#fff7ed"/>
       <stop offset="100%" stop-color="#fde68a"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><path d="M120 460 C 200 380, 260 520, 340 440 S 500 500, 540 420" stroke="#7c3e0a" stroke-width="10" fill="none" stroke-linecap="round" />
               <path d="M80 380 C 160 300, 220 440, 300 360 S 460 420, 520 340" stroke="#a16207" stroke-width="8" fill="none" stroke-linecap="round" /></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#1f2937">Rocco · shampoo</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Shampoo Curl Perfect 3</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">en 1 - 500 ml</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#7c3e0a"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">CAB-SHA-002</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/CAB-SHA-003.svg
+++ b/public/assets/products/CAB-SHA-003.svg
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#fff7ed"/>
       <stop offset="100%" stop-color="#fde68a"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><path d="M120 460 C 200 380, 260 520, 340 440 S 500 500, 540 420" stroke="#7c3e0a" stroke-width="10" fill="none" stroke-linecap="round" />
               <path d="M80 380 C 160 300, 220 440, 300 360 S 460 420, 520 340" stroke="#a16207" stroke-width="8" fill="none" stroke-linecap="round" /></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#1f2937">Rocco · shampoo</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Shampoo Jalea Real</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Anticaida - 400 ml</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#7c3e0a"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">CAB-SHA-003</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/TAZ-SCH-001.svg
+++ b/public/assets/products/TAZ-SCH-001.svg
@@ -1,30 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#ecfeff"/>
       <stop offset="100%" stop-color="#bae6fd"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><rect x="120" y="200" rx="24" ry="24" width="360" height="220" fill="#0ea5e9"/>
               <rect x="380" y="240" rx="40" ry="40" width="120" height="140" fill="none" stroke="#0ea5e9" stroke-width="20"/>
               <rect x="140" y="190" width="320" height="20" fill="#0c4a6e" opacity="0.4"/></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#0c4a6e">Kunstmann · schopero</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#0ea5e9">Tazon Schopero de Cobre</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#0ea5e9">Kunstmann 485 ml</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0c4a6e">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0c4a6e">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0c4a6e"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#0ea5e9"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">TAZ-SCH-001</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/TAZ-SCH-002.svg
+++ b/public/assets/products/TAZ-SCH-002.svg
@@ -1,30 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#ecfeff"/>
       <stop offset="100%" stop-color="#bae6fd"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><rect x="120" y="200" rx="24" ry="24" width="360" height="220" fill="#0ea5e9"/>
               <rect x="380" y="240" rx="40" ry="40" width="120" height="140" fill="none" stroke="#0ea5e9" stroke-width="20"/>
               <rect x="140" y="190" width="320" height="20" fill="#0c4a6e" opacity="0.4"/></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#0c4a6e">Kunstmann · schopero</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#0ea5e9">Tazon Schopero Acero</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#0ea5e9">Inoxidable Kunstmann 485</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0c4a6e">Un producto de alta calidad con</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0c4a6e">excelente diseño y rendimiento.</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0c4a6e"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#0ea5e9"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">TAZ-SCH-002</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/default-cabello.svg
+++ b/public/assets/products/default-cabello.svg
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#fff7ed"/>
       <stop offset="100%" stop-color="#fde68a"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><path d="M120 460 C 200 380, 260 520, 340 440 S 500 500, 540 420" stroke="#7c3e0a" stroke-width="10" fill="none" stroke-linecap="round" />
               <path d="M80 380 C 160 300, 220 440, 300 360 S 460 420, 520 340" stroke="#a16207" stroke-width="8" fill="none" stroke-linecap="round" /></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#1f2937">Genérico</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a">Cabello</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#7c3e0a"></text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937">Cuidado del cabello</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#1f2937"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#7c3e0a"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">default-cabello</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/default-tazon.svg
+++ b/public/assets/products/default-tazon.svg
@@ -1,30 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#ecfeff"/>
       <stop offset="100%" stop-color="#bae6fd"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><rect x="120" y="200" rx="24" ry="24" width="360" height="220" fill="#0ea5e9"/>
               <rect x="380" y="240" rx="40" ry="40" width="120" height="140" fill="none" stroke="#0ea5e9" stroke-width="20"/>
               <rect x="140" y="190" width="320" height="20" fill="#0c4a6e" opacity="0.4"/></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#0c4a6e">Genérico</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#0ea5e9">Tazón</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#0ea5e9"></text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0c4a6e">Utensilios de cocina</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0c4a6e"></text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0c4a6e"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#0ea5e9"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">default-tazon</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/public/assets/products/default.svg
+++ b/public/assets/products/default.svg
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#f1f5f9"/>
       <stop offset="100%" stop-color="#e2e8f0"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9"><circle cx="300" cy="300" r="120" fill="#64748b" opacity="0.35"/></g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="#0f172a">Marca</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#334155">Producto</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="#334155"></text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0f172a">Imagen por defecto</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0f172a"></text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="#0f172a"></text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="#334155"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">default</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>

--- a/scripts/generate-product-images.mjs
+++ b/scripts/generate-product-images.mjs
@@ -21,21 +21,7 @@ function escapeXml(s) {
     .replaceAll("'", '&#39;');
 }
 
-function wrapText(text, maxChars) {
-  const words = String(text || '').split(/\s+/).filter(Boolean);
-  const lines = [];
-  let current = '';
-  for (const word of words) {
-    if ((current + ' ' + word).trim().length > maxChars) {
-      if (current) lines.push(current.trim());
-      current = word;
-    } else {
-      current = (current + ' ' + word).trim();
-    }
-  }
-  if (current) lines.push(current.trim());
-  return lines.slice(0, 3);
-}
+// No text wrapping needed anymore as we removed textual overlays from SVGs
 
 function svgForCategory(category) {
   const c = String(category || '').toLowerCase();
@@ -70,42 +56,30 @@ function svgForCategory(category) {
 }
 
 function generateSvg(product) {
-  const id = product.id || 'PRODUCT';
-  const brand = product.brand || '';
-  const name = product.name || '';
-  const desc = product.description || '';
-  const subcategory = product.subcategory || '';
   const theme = svgForCategory(product.category);
-  const descLines = wrapText(desc, 36);
-  const nameLines = wrapText(name, 24);
-
   return `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Product image">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="${theme.bg1}"/>
       <stop offset="100%" stop-color="${theme.bg2}"/>
     </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" />
+    </filter>
+    <pattern id="subtleGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#000" stroke-opacity="0.03" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="600" height="600" fill="url(#bgGrad)"/>
+  <rect width="600" height="600" fill="url(#subtleGrid)"/>
   <g opacity="0.9">${theme.shape}</g>
-  <g>
-    <rect x="40" y="40" width="520" height="80" rx="16" ry="16" fill="white" opacity="0.7"/>
-    <text x="60" y="90" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="28" font-weight="700" fill="${theme.text}">${escapeXml(brand)}${subcategory ? ' · ' + escapeXml(subcategory) : ''}</text>
-  </g>
-  <g>
-    <text x="60" y="220" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="${theme.accent}">${escapeXml(nameLines[0] || '')}</text>
-    <text x="60" y="262" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="36" font-weight="800" fill="${theme.accent}">${escapeXml(nameLines[1] || '')}</text>
-  </g>
-  <g opacity="0.9">
-    <text x="60" y="340" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="${theme.text}">${escapeXml(descLines[0] || '')}</text>
-    <text x="60" y="370" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="${theme.text}">${escapeXml(descLines[1] || '')}</text>
-    <text x="60" y="400" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="20" font-weight="500" fill="${theme.text}">${escapeXml(descLines[2] || '')}</text>
-  </g>
-  <g>
-    <rect x="40" y="500" width="240" height="60" rx="12" ry="12" fill="${theme.accent}"/>
-    <text x="60" y="540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" font-size="22" font-weight="700" fill="white">${escapeXml(id)}</text>
-  </g>
+  <circle cx="460" cy="160" r="120" fill="url(#glow)" filter="url(#softBlur)" />
+  <circle cx="140" cy="460" r="140" fill="url(#glow)" filter="url(#softBlur)" />
 </svg>`;
 }
 

--- a/src/data/products.js
+++ b/src/data/products.js
@@ -6,7 +6,7 @@ export const products = [
     category: "cabello",
     subcategory: "shampoo",
     price: 19.99,
-    image: "https://picsum.photos/seed/product-1/600/600",
+    image: "https://source.unsplash.com/800x800/?shampoo,beauty&sig=1",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 0
   },
@@ -17,7 +17,7 @@ export const products = [
     category: "cabello",
     subcategory: "conditioner",
     price: 24.99,
-    image: "https://picsum.photos/seed/product-2/600/600",
+    image: "https://source.unsplash.com/800x800/?conditioner,beauty&sig=2",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 0
   },
@@ -28,7 +28,7 @@ export const products = [
     category: "cabello",
     subcategory: "aceite",
     price: 29.99,
-    image: "https://picsum.photos/seed/product-3/600/600",
+    image: "https://source.unsplash.com/800x800/?argan,oil,cosmetics&sig=3",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 1
   },
@@ -39,7 +39,7 @@ export const products = [
     category: "cabello",
     subcategory: "shampoo",
     price: 34.99,
-    image: "https://picsum.photos/seed/product-4/600/600",
+    image: "https://source.unsplash.com/800x800/?shampoo,haircare&sig=4",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 1
   },
@@ -50,7 +50,7 @@ export const products = [
     category: "cabello",
     subcategory: "conditioner",
     price: 22.99,
-    image: "https://picsum.photos/seed/product-5/600/600",
+    image: "https://source.unsplash.com/800x800/?conditioner,haircare&sig=5",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 1
   },
@@ -61,7 +61,7 @@ export const products = [
     category: "cabello",
     subcategory: "shampoo",
     price: 18.99,
-    image: "https://picsum.photos/seed/product-6/600/600",
+    image: "https://source.unsplash.com/800x800/?shampoo,bottle&sig=6",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 1
   },
@@ -72,7 +72,7 @@ export const products = [
     category: "cabello",
     subcategory: "conditioner",
     price: 21.49,
-    image: "https://picsum.photos/seed/product-7/600/600",
+    image: "https://source.unsplash.com/800x800/?conditioner,bottle&sig=7",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 1
   },
@@ -83,7 +83,7 @@ export const products = [
     category: "cabello",
     subcategory: "aceite",
     price: 27.49,
-    image: "https://picsum.photos/seed/product-8/600/600",
+    image: "https://source.unsplash.com/800x800/?hair,oil,dropper&sig=8",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 1
   },
@@ -94,7 +94,7 @@ export const products = [
     category: "cabello",
     subcategory: "aceite",
     price: 32.99,
-    image: "https://picsum.photos/seed/product-9/600/600",
+    image: "https://source.unsplash.com/800x800/?hair,oil,bottle&sig=9",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 1
   },
@@ -105,7 +105,7 @@ export const products = [
     category: "cabello",
     subcategory: "aceite",
     price: 14.99,
-    image: "https://picsum.photos/seed/product-10/600/600",
+    image: "https://source.unsplash.com/800x800/?moroccan,oil,beauty&sig=10",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 1
   },
@@ -116,7 +116,7 @@ export const products = [
     category: "tazon",
     subcategory: "schopero",
     price: 12.99,
-    image: "https://picsum.photos/seed/product-11/600/600",
+    image: "https://source.unsplash.com/800x800/?copper,mug&sig=11",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 1
   },
@@ -127,7 +127,7 @@ export const products = [
     category: "tazon",
     subcategory: "schopero",
     price: 13.99,
-    image: "https://picsum.photos/seed/product-12/600/600",
+    image: "https://source.unsplash.com/800x800/?stainless,steel,mug&sig=12",
     description: "Un producto de alta calidad con excelente diseño y rendimiento.",
     stock: 1
   }

--- a/src/lib/images.js
+++ b/src/lib/images.js
@@ -12,6 +12,16 @@
  * @returns {string}
  */
 export function resolveProductImage(product = {}) {
+  const explicitImage = String(product.image || '').trim();
+  const isHttp = (url) => /^(https?:)?\/\//.test(url);
+  const isAbsolutePublic = (url) => typeof url === 'string' && url.startsWith('/');
+
+  // If a product already provides an image (remote URL or absolute public path), respect it.
+  if (explicitImage && (isHttp(explicitImage) || isAbsolutePublic(explicitImage))) {
+    return explicitImage;
+  }
+
+  // Otherwise, fall back to our deterministic local asset by id or category defaults.
   const productId = (product.id || '').trim();
   if (productId) {
     return `/assets/products/${productId}.svg`;


### PR DESCRIPTION
- Respeta product.image remoto si existe
- Reemplaza imagenes en src/data/products.js por Unsplash tematicas
- Quita overlays de texto del generador y regenera assets
- Mejora fallback visual por categoria/id