### PR TITLE
Send email to support without text box

### DIFF
--- a/src/components/ContactSection.jsx
+++ b/src/components/ContactSection.jsx
@@ -13,7 +13,7 @@ export default function ContactSection() {
     const email = form.email?.value?.trim() || '';
     const mensaje = form.mensaje?.value?.trim() || '';
 
-    if (!email) {
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
       form.email?.focus();
       return;
     }
@@ -27,12 +27,12 @@ export default function ContactSection() {
     lines.push(mensaje || '');
 
     const body = encodeURIComponent(lines.join('\n'));
-    const href = `mailto:${encodeURIComponent(supportEmail)}?subject=${encodeURIComponent(subject)}&body=${body}`;
+    const href = `mailto:${encodeURIComponent(email)}?subject=${encodeURIComponent(subject)}&body=${body}`;
 
     setIsSubmitting(true);
     setFeedbackMessage('');
     try {
-      await sendContactEmail({ toEmail: supportEmail, toName: 'Soporte', subject, message: lines.join('\n') });
+      await sendContactEmail({ toEmail: email, toName: 'Soporte', subject, message: lines.join('\n') });
       form.reset();
       setFeedbackMessage('Mensaje enviado. Te responderemos pronto.');
     } catch (err) {


### PR DESCRIPTION
Update contact form to send emails to the user-entered address instead of a hardcoded support email.

The previous implementation hardcoded the recipient to `soporte@mundobbelleza.cl`, ignoring the email provided in the contact form's textbox. This change ensures the email is sent to the address entered by the user, and also adds a basic email format validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-1bad3b11-534b-4ee8-857d-ebe4b4ab5c8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1bad3b11-534b-4ee8-857d-ebe4b4ab5c8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

