### PR TITLE
Move contact form from product page

### DIFF
--- a/src/themes/shared/Layout.jsx
+++ b/src/themes/shared/Layout.jsx
@@ -6,9 +6,12 @@ import { Helmet } from 'react-helmet-async';
 import { useSEO } from '../../contexts/SEOContext.jsx';
 import AuthModal from '../../ui/AuthModal.jsx';
 import ContactSection from '../../components/ContactSection.jsx';
+import { useLocation } from 'react-router-dom';
 
 export default function Layout({ children }) {
   const { title, description } = useSEO();
+  const location = useLocation();
+  const isProductDetailPage = /^\/products\/[^/]+$/.test(location.pathname);
 
   return (
     <div className="d-flex flex-column min-vh-100">
@@ -23,7 +26,7 @@ export default function Layout({ children }) {
           {children}
         </div>
       </main>
-      <ContactSection />
+      {!isProductDetailPage && <ContactSection />}
       <Footer />
       <AuthModal />
     </div>


### PR DESCRIPTION
Hide the contact section on product detail pages because it was inappropriately displayed there.

---
<a href="https://cursor.com/background-agent?bcId=bc-e38f142e-b34c-44ef-96d1-d91648be1aad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e38f142e-b34c-44ef-96d1-d91648be1aad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

