### PR TITLE
Ajustar imagenes de categorias a carruseles

### DIFF
--- a/src/themes/default/Home.jsx
+++ b/src/themes/default/Home.jsx
@@ -1,89 +1,65 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 import { useSEO } from '../../contexts/SEOContext.jsx';
 
 export default function Home() {
-  const { t } = useTranslation();
   const { setTitle, setDescription } = useSEO();
+  const scrollRef = useRef(null);
+
+  const handlePrev = () => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollBy({ left: -320, behavior: 'smooth' });
+    }
+  };
+
+  const handleNext = () => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollBy({ left: 320, behavior: 'smooth' });
+    }
+  };
 
   useEffect(() => {
     setTitle('Mundo Belleza — Inicio');
     setDescription('Descubre nuestra colección de productos profesionales para el cuidado del cabello, accesorios y ofertas especiales.');
   }, [setTitle, setDescription]);
 
+  const categories = [
+    { title: 'Cabello', slug: 'cabello', image: '/images/categories/cabello_600x600.png', link: '/products?category=cabello' },
+    { title: 'Tazones', slug: 'tazones', image: '/images/categories/tazones_600x600.png', link: '/products?category=tazon&subcategory=schopero' },
+    { title: 'Accesorios', slug: 'accesorios', image: '/images/categories/accesorios.svg', link: '/products?category=accesorios' },
+    { title: 'Ofertas', slug: 'ofertas', image: '/images/categories/ofertas.svg', link: '/products?category=ofertas' }
+  ];
+
   return (
     <div className="home-page">
-      {/* Hero */}
-      <section className="hero position-relative overflow-hidden rounded-4 p-4 p-md-5 mb-4">
-        <div className="row align-items-center g-4">
-          <div className="col-12 col-lg-6">
-            <h1 className="display-5 fw-bold mb-3 text-white">
-              {t('home.heroTitle')}
-            </h1>
-            <p className="lead text-white-50 mb-4">
-              {t('home.heroSubtitle')}
-            </p>
-            <div className="d-flex gap-2">
-              <Link to="/products" className="btn btn-primary btn-lg">{t('home.cta')}</Link>
-              <Link to="/blog" className="btn btn-outline-light btn-lg">Blog</Link>
-            </div>
-          </div>
-          <div className="col-12 col-lg-6">
-            <div className="hero-gallery rounded-4 shadow-lg">
-              <div className="gallery-grid">
-                <Link to="/products?category=cabello" className="gallery-card item-a" aria-label="Explorar productos de Cabello">
-                  <img src="/images/categories/cabello_1024x1024.png" alt="Colección Cabello" loading="eager" />
-                  <span className="gallery-label">Cabello</span>
-                </Link>
-                <Link to="/products?category=tazon&subcategory=schopero" className="gallery-card item-b" aria-label="Explorar Tazones">
-                  <img src="/images/categories/tazones_600x600.png" alt="Colección Tazones" loading="lazy" />
-                  <span className="gallery-label">Tazones</span>
-                </Link>
-                <Link to="/products?category=accesorios" className="gallery-card item-c" aria-label="Explorar Accesorios">
-                  <img src="/images/categories/accesorios.svg" alt="Accesorios" loading="lazy" />
-                  <span className="gallery-label">Accesorios</span>
-                </Link>
-                <Link to="/products?category=ofertas" className="gallery-card item-d" aria-label="Ver Ofertas">
-                  <img src="/images/categories/ofertas.svg" alt="Ofertas especiales" loading="lazy" />
-                  <span className="gallery-label">Ofertas</span>
-                </Link>
-                <Link to="/products?category=cabello&subcategory=aceite" className="gallery-card item-e" aria-label="Explorar Aceites capilares">
-                  <img src="/images/categories/cabello.svg" alt="Aceites capilares" loading="lazy" />
-                  <span className="gallery-label">Aceites</span>
-                </Link>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="hero-bg" aria-hidden="true" />
-      </section>
-
-      {/* Categorías destacadas */}
-      <section className="mb-5">
-        <div className="d-flex align-items-center justify-content-between mb-3">
-          <h2 className="h4 mb-0">Categorías destacadas</h2>
+      <section className="mb-4 category-carousel">
+        <div className="d-flex align-items-center justify-content-between mb-2">
+          <h2 className="h5 mb-0">Categorías</h2>
           <Link to="/products" className="btn btn-sm btn-outline-secondary">Ver todo</Link>
         </div>
-        <div className="row g-3 g-md-4">
-          {[
-            { title: 'Cabello', slug: 'cabello', image: '/images/categories/cabello_600x600.png', query: 'category=cabello&subcategory=shampoo,conditioner' },
-            { title: 'Tazones', slug: 'tazones', image: '/images/categories/tazones_600x600.png', query: 'category=tazon&subcategory=schopero' },
-            { title: 'Aceites Capilares', slug: 'aceites capilares', image: '/images/categories/aceites_capilares_600x600.png', query: 'category=cabello&subcategory=aceite' }
-          ].map((cat) => (
-            <div key={cat.slug} className="col-12 col-md-4">
-              <Link to={`/products?${cat.query}`} className="text-decoration-none">
-                <div className="card category-card h-100 overflow-hidden">
-                  <img src={cat.image} className="card-img-top" alt={cat.title} loading="lazy" style={{ objectFit: 'contain', aspectRatio: '4 / 3', backgroundColor: '#fff' }} />
-                  <div className="card-img-overlay d-flex align-items-end p-0">
-                    <div className="w-100 p-3 category-overlay">
-                      <h3 className="h5 mb-0 text-white">{cat.title}</h3>
+        <div className="position-relative">
+          <button type="button" className="btn btn-light btn-sm carousel-btn prev" aria-label="Anterior" onClick={handlePrev}>
+            ‹
+          </button>
+          <div ref={scrollRef} className="category-scroll" role="region" aria-label="Carrusel de categorías">
+            {categories.map((cat) => (
+              <div key={cat.slug} className="carousel-item-card">
+                <Link to={cat.link} className="text-decoration-none d-block">
+                  <div className="card h-100 overflow-hidden">
+                    <div className="p-2 bg-white">
+                      <img src={cat.image} alt={cat.title} loading="lazy" className="w-100" style={{ height: '120px', objectFit: 'contain' }} />
+                    </div>
+                    <div className="p-2 text-center">
+                      <span className="small fw-semibold text-dark">{cat.title}</span>
                     </div>
                   </div>
-                </div>
-              </Link>
-            </div>
-          ))}
+                </Link>
+              </div>
+            ))}
+          </div>
+          <button type="button" className="btn btn-light btn-sm carousel-btn next" aria-label="Siguiente" onClick={handleNext}>
+            ›
+          </button>
         </div>
       </section>
     </div>

--- a/src/themes/shared/theme.css
+++ b/src/themes/shared/theme.css
@@ -299,6 +299,47 @@ main:focus {
   background: linear-gradient(to top, rgba(30,30,30,0.75), rgba(30,30,30,0.0));
 }
 
+/* ==============================
+   Compact horizontal category carousel
+   ============================== */
+.category-carousel .category-scroll {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 180px;
+  gap: .75rem;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  padding: .25rem .25rem .5rem;
+}
+.category-carousel .category-scroll::-webkit-scrollbar {
+  height: 8px;
+}
+.category-carousel .category-scroll::-webkit-scrollbar-thumb {
+  background: rgba(0,0,0,0.15);
+  border-radius: 999px;
+}
+.category-carousel .carousel-item-card {
+  width: 180px;
+}
+.category-carousel .carousel-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  border-radius: 999px;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.12);
+}
+.category-carousel .carousel-btn.prev { left: -8px; }
+.category-carousel .carousel-btn.next { right: -8px; }
+
+@media (max-width: 575.98px) {
+  .category-carousel .category-scroll {
+    grid-auto-columns: 150px;
+    gap: .5rem;
+  }
+  .category-carousel .carousel-item-card { width: 150px; }
+}
+
 /* ==========================================
    Product Detail Styling (brand-aligned)
    ========================================== */


### PR DESCRIPTION
Replace the home page's hero and category grid with a compact, horizontal category carousel to reduce its size.

---
<a href="https://cursor.com/background-agent?bcId=bc-3318d864-73ad-4479-873d-1ba50f62aad9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3318d864-73ad-4479-873d-1ba50f62aad9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

