### PR TITLE
Format currency with thousands separator

### DIFF
--- a/src/themes/default/Cart.jsx
+++ b/src/themes/default/Cart.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useCart } from '../../contexts/CartContext.jsx';
+import { formatCLP } from '../shared/format.js';
 
 export default function Cart() {
   const {
@@ -14,7 +15,7 @@ export default function Cart() {
     removeItem,
   } = useCart();
 
-  const formatCurrency = (value) => `$${value}`;
+  const formatCurrency = (value) => formatCLP(value);
 
   return (
     <div className="container py-4">

--- a/src/themes/default/Checkout.jsx
+++ b/src/themes/default/Checkout.jsx
@@ -5,6 +5,7 @@ import { useUser } from '../../contexts/UserContext.jsx';
 import { useSEO } from '../../contexts/SEOContext.jsx';
 import PayPalCheckout from '../../ui/PayPalCheckout.jsx';
 import { IVA_RATE } from '../../lib/config.js';
+import { formatCLP } from '../shared/format.js';
 
 export default function Checkout() {
   const navigate = useNavigate();
@@ -293,27 +294,27 @@ export default function Checkout() {
                       <div className="text-muted small">Cantidad: {it.quantity || 1}</div>
                     </div>
                   </div>
-                  <div className="small fw-semibold">${((it.price || 0) * (it.quantity || 1))}</div>
+                  <div className="small fw-semibold">{formatCLP((it.price || 0) * (it.quantity || 1))}</div>
                 </li>
               ))}
             </ul>
 
             <div className="d-flex justify-content-between mb-2">
               <span>Subtotal</span>
-              <strong>${cartSubtotal}</strong>
+              <strong>{formatCLP(cartSubtotal)}</strong>
             </div>
             <div className="d-flex justify-content-between mb-2">
               <span>Envío</span>
-              <strong>${shippingCost}</strong>
+              <strong>{formatCLP(shippingCost)}</strong>
             </div>
             <div className="d-flex justify-content-between mb-2">
               <span>IVA</span>
-              <strong>${tax}</strong>
+              <strong>{formatCLP(tax)}</strong>
             </div>
             <hr />
             <div className="d-flex justify-content-between">
               <span>Total</span>
-              <strong>${total}</strong>
+              <strong>{formatCLP(total)}</strong>
             </div>
           </div>
         </div>

--- a/src/themes/default/ProductDetail.jsx
+++ b/src/themes/default/ProductDetail.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useCart } from '../../contexts/CartContext.jsx';
 import { getProductByIdApi } from '../../lib/api.js';
+import { formatCLP } from '../shared/format.js';
 
 export default function ProductDetail() {
   const { id } = useParams();
@@ -83,7 +84,7 @@ export default function ProductDetail() {
             <p className="product-description lead mb-4">{product.description}</p>
 
             <div className="d-flex flex-column flex-sm-row align-items-sm-center gap-3">
-              <div className="price-highlight">${product.price}</div>
+              <div className="price-highlight">{formatCLP(product.price)}</div>
               <button
                 type="button"
                 className="btn btn-primary btn-lg btn-add-cart"

--- a/src/themes/default/Products.jsx
+++ b/src/themes/default/Products.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useCart } from '../../contexts/CartContext.jsx';
 import { getProducts } from '../../lib/api.js';
+import { formatCLP } from '../shared/format.js';
 
 
 
@@ -275,7 +276,7 @@ const handleAddToCart = (product) => {
                 )}
 
                 <div className="mt-auto d-flex align-items-center justify-content-between">
-                        <span className="price h6 mb-0">${product.price}</span>
+                        <span className="price h6 mb-0">{formatCLP(product.price)}</span>
                         <button
                           className="btn btn-sm btn-primary"
                           disabled={product.stock === 0}

--- a/src/themes/shared/format.js
+++ b/src/themes/shared/format.js
@@ -1,0 +1,24 @@
+// Simple currency formatter for Chilean Peso with thousands separator and no decimals
+// Usage: formatCLP(1234567) => "$1.234.567"
+
+/**
+ * Format a number as Chilean Peso currency with thousands separator and no decimals.
+ * Returns a string like "$1.234.567". Gracefully handles invalid inputs.
+ * @param {number|string|null|undefined} value
+ * @returns {string}
+ */
+export function formatCLP(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return "$0";
+  try {
+    return new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP', maximumFractionDigits: 0 }).format(numeric);
+  } catch (_) {
+    // Fallback formatting if Intl is not available
+    const rounded = Math.round(numeric);
+    const parts = Math.abs(rounded).toString().split('').reverse();
+    const withDots = parts.reduce((acc, ch, idx) => acc + ch + ((idx + 1) % 3 === 0 && idx + 1 < parts.length ? '.' : ''), '').split('').reverse().join('');
+    const sign = rounded < 0 ? '-' : '';
+    return `${sign}$${withDots}`;
+  }
+}
+


### PR DESCRIPTION
Add a shared Chilean Peso formatter and apply it to product, cart, and checkout pages for consistent price display.

---
<a href="https://cursor.com/background-agent?bcId=bc-68643475-74d5-4db1-8b24-e07e2f20e19b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68643475-74d5-4db1-8b24-e07e2f20e19b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

