### PR TITLE
Remove decimals on success page

### DIFF
--- a/src/themes/shared/format.js
+++ b/src/themes/shared/format.js
@@ -11,7 +11,7 @@ export function formatCLP(value) {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return "$0";
   try {
-    return new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP', maximumFractionDigits: 0 }).format(numeric);
+    return new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(numeric);
   } catch (_) {
     // Fallback formatting if Intl is not available
     const rounded = Math.round(numeric);


### PR DESCRIPTION
Set `minimumFractionDigits` to 0 in `formatCLP` to ensure no decimals are displayed for CLP currency on the success page.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1b91c0b-d6f0-4921-a379-2b3a18c78756">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1b91c0b-d6f0-4921-a379-2b3a18c78756">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

