### PR TITLE
Translate ecommerce pages to Spanish for SEO

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,9 +20,13 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/products" element={<Products />} />
         <Route path="/products/:id" element={<ProductDetail />} />
-        <Route path="/cart" element={<Cart />} />
-        <Route path="/checkout" element={<Checkout />} />
-        <Route path="/order/success" element={<OrderSuccess />} />
+        <Route path="/carrito" element={<Cart />} />
+        <Route path="/finalizar-compra" element={<Checkout />} />
+        <Route path="/confirmacion-pedido" element={<OrderSuccess />} />
+        {/* Redirecciones desde rutas antiguas (client-side) */}
+        <Route path="/cart" element={<Navigate to="/carrito" replace />} />
+        <Route path="/checkout" element={<Navigate to="/finalizar-compra" replace />} />
+        <Route path="/order/success" element={<Navigate to="/confirmacion-pedido" replace />} />
         <Route path="/blog" element={<Blog />} />
         <Route path="/blog/:slug" element={<BlogDetail />} />
         <Route path="/preguntas-frecuentes" element={<PreguntasFrecuentes />} />

--- a/src/themes/default/Cart.jsx
+++ b/src/themes/default/Cart.jsx
@@ -113,8 +113,8 @@ export default function Cart() {
                   <span>Subtotal</span>
                   <strong>{formatCurrency(cartSubtotal)}</strong>
                 </div>
-                <div className="text-muted small mb-3">El envío y los impuestos se calculan en el checkout.</div>
-                <Link to="/checkout" className="btn btn-primary w-100">Proceder al pago</Link>
+                <div className="text-muted small mb-3">El envío y los impuestos se calculan al finalizar la compra.</div>
+                <Link to="/finalizar-compra" className="btn btn-primary w-100">Proceder al pago</Link>
               </div>
             </div>
           </div>

--- a/src/themes/default/Checkout.jsx
+++ b/src/themes/default/Checkout.jsx
@@ -32,7 +32,7 @@ export default function Checkout() {
   const [errors, setErrors] = useState({});
 
   useEffect(() => {
-    setTitle('Checkout');
+    setTitle('Finalizar compra');
     setDescription('Completa tu compra de forma segura.');
   }, [setTitle, setDescription]);
 
@@ -118,7 +118,7 @@ export default function Checkout() {
       sessionStorage.setItem('last_order', JSON.stringify(orderSnapshot));
     } catch {}
     clearCart();
-    navigate(`/order/success?orderId=${orderId}`);
+    navigate(`/confirmacion-pedido?orderId=${orderId}`);
   }
 
   async function handleSubmit(e) {
@@ -138,7 +138,7 @@ export default function Checkout() {
     return (
       <div className="text-center py-5">
         <h1 className="h4 mb-2">Tu carrito está vacío</h1>
-        <p className="text-muted mb-4">Agrega productos para continuar al checkout.</p>
+        <p className="text-muted mb-4">Agrega productos para continuar a finalizar compra.</p>
         <Link className="btn btn-primary" to="/products">Explorar productos</Link>
       </div>
     );
@@ -273,7 +273,7 @@ export default function Checkout() {
           </div>
 
           <div className="d-flex justify-content-end gap-2">
-            <Link to="/cart" className="btn btn-outline-secondary">Volver al carrito</Link>
+            <Link to="/carrito" className="btn btn-outline-secondary">Volver al carrito</Link>
             <button type="submit" className="btn btn-primary" disabled={isSubmitting || form.paymentMethod === 'paypal'}>
               {isSubmitting ? 'Procesando…' : 'Confirmar pedido'}
             </button>

--- a/src/themes/default/EnviosYDevoluciones.jsx
+++ b/src/themes/default/EnviosYDevoluciones.jsx
@@ -74,7 +74,7 @@ export default function EnviosYDevoluciones() {
                 >
                   <div className="card-body">
                     <p className="mb-0">
-                      El costo se calcula automáticamente en el checkout según tu dirección y el peso del pedido.
+                      El costo se calcula automáticamente al finalizar la compra según tu dirección y el peso del pedido.
                       Ofrecemos envío gratis desde montos promocionales cuando estén vigentes.
                     </p>
                   </div>

--- a/src/themes/default/OrderSuccess.jsx
+++ b/src/themes/default/OrderSuccess.jsx
@@ -21,7 +21,7 @@ export default function OrderSuccess() {
   const order = raw ? JSON.parse(raw) : null;
 
   useEffect(() => {
-    setTitle('Pedido confirmado');
+    setTitle('Confirmación de pedido');
     setDescription('Resumen de tu compra');
   }, [setTitle, setDescription]);
 

--- a/src/themes/default/PreguntasFrecuentes.jsx
+++ b/src/themes/default/PreguntasFrecuentes.jsx
@@ -10,7 +10,7 @@ const faqs = [
   {
     question: '¿Cuánto cuesta el envío?',
     answer:
-      'El costo de envío se calcula automáticamente en el checkout según tu dirección y el peso del pedido. Ofrecemos envío gratis a partir de un monto mínimo promocional cuando esté vigente.'
+      'El costo de envío se calcula automáticamente al finalizar la compra según tu dirección y el peso del pedido. Ofrecemos envío gratis a partir de un monto mínimo promocional cuando esté vigente.'
   },
   {
     question: '¿Puedo devolver un producto?',
@@ -35,7 +35,7 @@ const faqs = [
   {
     question: '¿Cómo solicito factura?',
     answer:
-      'Puedes solicitar tu factura ingresando los datos de facturación en el checkout o escribiéndonos luego de tu compra con tu número de pedido.'
+      'Puedes solicitar tu factura ingresando los datos de facturación al finalizar la compra o escribiéndonos luego de tu compra con tu número de pedido.'
   },
   {
     question: '¿Hay garantía?',

--- a/src/themes/shared/Breadcrumbs.jsx
+++ b/src/themes/shared/Breadcrumbs.jsx
@@ -4,8 +4,9 @@ import { Link, useLocation, matchPath } from 'react-router-dom';
 const nameMap = {
   '': 'Inicio',
   products: 'Productos',
-  cart: 'Carrito',
-  checkout: 'Pagar',
+  'carrito': 'Carrito',
+  'finalizar-compra': 'Finalizar compra',
+  'confirmacion-pedido': 'Confirmación de pedido',
   blog: 'Blog',
   'preguntas-frecuentes': 'Preguntas frecuentes',
   'envios-y-devoluciones': 'Envíos y devoluciones',

--- a/src/themes/shared/Footer.jsx
+++ b/src/themes/shared/Footer.jsx
@@ -52,8 +52,8 @@ export default function Footer() {
                 <li><Link to="/">Inicio</Link></li>
                 <li><Link to="/products">Productos</Link></li>
                 <li><Link to="/blog">Blog</Link></li>
-                <li><Link to="/cart">Carrito</Link></li>
-                <li><Link to="/checkout">Pagar</Link></li>
+                <li><Link to="/carrito">Carrito</Link></li>
+                <li><Link to="/finalizar-compra">Pagar</Link></li>
               </ul>
             </div>
 

--- a/src/themes/shared/Header.jsx
+++ b/src/themes/shared/Header.jsx
@@ -106,9 +106,9 @@ export default function Header() {
 
           <ul className="navbar-nav ms-auto">
             <li className="nav-item me-2">
-              <NavLink to="/cart" className="nav-link position-relative">
+              <NavLink to="/carrito" className="nav-link position-relative">
                 {t('common.cart')}
-                <span className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-primary" aria-label={`Items in cart: ${cartItemsCount}`}>
+                <span className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-primary" aria-label={`Artículos en el carrito: ${cartItemsCount}`}>
                   {cartItemsCount}
                 </span>
               </NavLink>

--- a/src/themes/shared/Layout.jsx
+++ b/src/themes/shared/Layout.jsx
@@ -11,17 +11,23 @@ import { useLocation } from 'react-router-dom';
 export default function Layout({ children }) {
   const { title, description } = useSEO();
   const location = useLocation();
+  const baseUrl = import.meta.env.VITE_APP_SITE_URL || '';
+  const canonicalHref = baseUrl
+    ? `${String(baseUrl).replace(/\/$/, '')}${location.pathname}${location.search || ''}`
+    : null;
   const isProductDetailPage = /^\/products\/[^/]+$/.test(location.pathname);
   const isProductsListPage = location.pathname === '/products';
-  const isCartPage = location.pathname === '/cart';
-  const isCheckoutPage = location.pathname === '/checkout';
-  const isOrderSuccessPage = location.pathname === '/order/success';
+  const isCartPage = location.pathname === '/carrito';
+  const isCheckoutPage = location.pathname === '/finalizar-compra';
+  const isOrderSuccessPage = location.pathname === '/confirmacion-pedido';
 
   return (
     <div className="d-flex flex-column min-vh-100">
       <Helmet>
         <title>{title}</title>
         {description && <meta name="description" content={description} />}
+        <meta property="og:locale" content="es_ES" />
+        {canonicalHref && <link rel="canonical" href={canonicalHref} />}
       </Helmet>
       <Header />
       <main id="main" tabIndex="-1" className="flex-grow-1 py-3" role="main">


### PR DESCRIPTION
Traduce las páginas de carrito, pago y confirmación de pedido a español para mejorar el SEO y la coherencia de la experiencia de usuario.

Se han renombrado las rutas (`/cart` a `/carrito`, `/checkout` a `/finalizar-compra`, `/order/success` a `/confirmacion-pedido`), se han añadido redirecciones client-side, y se han actualizado títulos, breadcrumbs, enlaces internos y textos relevantes a lo largo del sitio. También se añadió `og:locale` y un `canonical` dinámico para optimización SEO.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f57417f-f91c-45e6-a28e-42be09e32d62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1f57417f-f91c-45e6-a28e-42be09e32d62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

