### PR TITLE
Debug product api 404 error

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -12,7 +12,9 @@ export async function fetchJson(url, options = {}) {
       message = await safeReadJson(response);
     } else {
       const text = await response.text();
-      message = { message: (text || '').slice(0, 200) };
+      const snippet = (text || '').slice(0, 200);
+      // Include both message and snippet so fallback logic can detect HTML responses
+      message = { message: snippet, snippet };
     }
     const error = new Error(message?.message || `Request failed with status ${response.status}`);
     error.status = response.status;


### PR DESCRIPTION
Include response snippet in `fetchJson` errors to enable mock fallback for non-JSON 404s.

This change allows the mock fallback mechanism to correctly identify HTML 404 responses (e.g., from Amplify when no backend is present), ensuring that local mock data can be used in staging environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-031db8f4-8c5a-490e-b4e0-dc9ccd68d617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-031db8f4-8c5a-490e-b4e0-dc9ccd68d617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

