### PR TITLE
Usar datos mock para productos

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -42,29 +42,15 @@ async function safeReadJson(response) {
 import { attachImages, attachImageToProduct } from './images.js';
 
 export async function getProducts() {
-  try {
-    const data = await fetchJson('/api/products');
-    return attachImages(data);
-  } catch (error) {
-    if (shouldFallbackToMock(error)) {
-      const { products } = await import('../data/products.js');
-      return attachImages(products);
-    }
-    throw error;
-  }
+  // Force using local mock data to avoid hitting non-existent API in production
+  const { products } = await import('../data/products.js');
+  return attachImages(products);
 }
 
 export async function getProductByIdApi(id) {
-  try {
-    const data = await fetchJson(`/api/products/${encodeURIComponent(id)}`);
-    return attachImageToProduct(data);
-  } catch (error) {
-    if (shouldFallbackToMock(error)) {
-      const { getProductById } = await import('../data/products.js');
-      return attachImageToProduct(getProductById(id));
-    }
-    throw error;
-  }
+  // Force using local mock data to avoid hitting non-existent API in production
+  const { getProductById } = await import('../data/products.js');
+  return attachImageToProduct(getProductById(id));
 }
 
 function shouldFallbackToMock(error) {


### PR DESCRIPTION
Force `getProducts` and `getProductByIdApi` to use local mock data to prevent crashes on AWS Amplify due to missing backend API.

---
<a href="https://cursor.com/background-agent?bcId=bc-dda09824-804e-452a-8eb5-80ad9b60287d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dda09824-804e-452a-8eb5-80ad9b60287d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

