### PR TITLE
Fix cart quantity display bug

### DIFF
--- a/src/themes/default/Cart.jsx
+++ b/src/themes/default/Cart.jsx
@@ -60,7 +60,11 @@ export default function Cart() {
                       </div>
 
                       <div className="d-flex align-items-center mt-3 gap-2">
-                        <div className="btn-group" role="group" aria-label={`Cambiar cantidad para ${it.name}`}>
+                        <div
+                          className="input-group input-group-sm"
+                          aria-label={`Cambiar cantidad para ${it.name}`}
+                          style={{ maxWidth: 200 }}
+                        >
                           <button
                             type="button"
                             className="btn btn-outline-secondary"
@@ -72,7 +76,7 @@ export default function Cart() {
                           <input
                             type="number"
                             className="form-control text-center"
-                            style={{ maxWidth: 80 }}
+                            style={{ width: 80 }}
                             min={1}
                             value={it.quantity || 1}
                             onChange={(e) => {


### PR DESCRIPTION
Fix quantity display on cart page by using Bootstrap `input-group` and setting a fixed width for the input field.

---
<a href="https://cursor.com/background-agent?bcId=bc-e331cb8f-01f6-47bd-a576-99412f5e27e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e331cb8f-01f6-47bd-a576-99412f5e27e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

