### PR TITLE
Fix cart quantity visibility on Samsung

### DIFF
--- a/src/themes/default/Cart.jsx
+++ b/src/themes/default/Cart.jsx
@@ -60,7 +60,12 @@ export default function Cart() {
                       </div>
 
                       <div className="d-flex align-items-center mt-3 gap-2">
-                        <div className="btn-group" role="group" aria-label={`Cambiar cantidad para ${it.name}`}>
+                        <div
+                          className="input-group input-group-sm"
+                          role="group"
+                          aria-label={`Cambiar cantidad para ${it.name}`}
+                          style={{ maxWidth: 180 }}
+                        >
                           <button
                             type="button"
                             className="btn btn-outline-secondary"
@@ -71,8 +76,9 @@ export default function Cart() {
                           </button>
                           <input
                             type="number"
-                            className="form-control text-center"
-                            style={{ maxWidth: 80 }}
+                            inputMode="numeric"
+                            pattern="[0-9]*"
+                            className="form-control text-center cart-qty-input"
                             min={1}
                             value={it.quantity || 1}
                             onChange={(e) => {

--- a/src/themes/shared/theme.css
+++ b/src/themes/shared/theme.css
@@ -206,6 +206,24 @@ main:focus {
   background: linear-gradient(135deg, rgba(30,30,30,0.85), rgba(212,175,55,0.25));
 }
 
+/* ==================================================
+   Cart quantity input visibility (legacy Android fix)
+   Ensures the number is visible on devices where the
+   default input color may be white on white.
+   ================================================== */
+.cart-qty-input {
+  color: #212529 !important; /* Bootstrap body color */
+  background-color: #fff !important;
+  -webkit-text-fill-color: #212529; /* iOS/Android WebKit */
+}
+.cart-qty-input::placeholder {
+  color: rgba(0,0,0,0.4);
+}
+input[type="number"].cart-qty-input::-webkit-outer-spin-button,
+input[type="number"].cart-qty-input::-webkit-inner-spin-button {
+  opacity: 1; /* keep visible for usability on older Android */
+}
+
 /* ==========================
    Blog styling (brand-aligned)
    ========================== */


### PR DESCRIPTION
Refactor cart quantity control and add CSS fixes to ensure visibility on legacy Android devices.

The quantity text was appearing blank on older Android devices (e.g., Samsung Grand Neo) due to default browser styling rendering white text on a white background within the number input. This PR converts the control to a Bootstrap `input-group` and applies targeted CSS to force visible text and background colors.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf3632de-5507-4bb7-93ee-723b167ed4f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf3632de-5507-4bb7-93ee-723b167ed4f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

