### PR TITLE
Hide blog and admin menu

### DIFF
--- a/src/themes/shared/Footer.jsx
+++ b/src/themes/shared/Footer.jsx
@@ -51,7 +51,6 @@ export default function Footer() {
               <ul className="list-unstyled footer-links">
                 <li><Link to="/">Inicio</Link></li>
                 <li><Link to="/products">Productos</Link></li>
-                <li><Link to="/blog">Blog</Link></li>
                 <li><Link to="/carrito">Carrito</Link></li>
                 <li><Link to="/finalizar-compra">Pagar</Link></li>
               </ul>

--- a/src/themes/shared/Header.jsx
+++ b/src/themes/shared/Header.jsx
@@ -3,7 +3,6 @@ import { Link, NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useCart } from '../../contexts/CartContext.jsx';
 import { useUser } from '../../contexts/UserContext.jsx';
-import { APP_ENVIRONMENT } from '../../lib/config.js';
 
 export default function Header() {
   const { t } = useTranslation();
@@ -65,19 +64,7 @@ export default function Header() {
               </NavLink>
             </li>
 
-            <li className="nav-item">
-              <NavLink to="/blog" className="nav-link">
-                {t('common.blog')}
-              </NavLink>
-            </li>
-
-            {(APP_ENVIRONMENT !== 'prod' || user?.role === 'admin') && (
-              <li className="nav-item">
-                <NavLink to="/admin" className="nav-link">
-                  Admin
-                </NavLink>
-              </li>
-            )}
+            
 
             {/* <li className="nav-item dropdown">
               <button className="nav-link dropdown-toggle" data-bs-toggle="dropdown">
@@ -135,11 +122,6 @@ export default function Header() {
                   {user.name || t('common.account')}
                 </button>
                 <ul className="dropdown-menu dropdown-menu-end">
-                  {user?.role === 'admin' && (
-                    <li>
-                      <Link className="dropdown-item" to="/admin">Panel de administración</Link>
-                    </li>
-                  )}
                   <li>
                     <button className="dropdown-item" onClick={logout}>{t('common.logout')}</button>
                   </li>


### PR DESCRIPTION
Remove Blog and Admin menu items from header and footer to hide them from view.

---
<a href="https://cursor.com/background-agent?bcId=bc-099281e8-e99b-4bce-a06a-6cbc7a2f6a1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-099281e8-e99b-4bce-a06a-6cbc7a2f6a1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

